### PR TITLE
Add LLM Ask feature for entries

### DIFF
--- a/app/views/entries/_form.html.erb
+++ b/app/views/entries/_form.html.erb
@@ -75,8 +75,9 @@
       <p class="mt-2 text-sm text-gray-500">You can select multiple files. New selections will be added to your existing selections. Files will be encrypted just like your entry content.</p>
     </div>
 
-    <div class="flex justify-end">
+    <div class="flex justify-end space-x-2">
       <%= form.submit class: "w-full sm:w-auto rounded-md shadow-sm px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+      <%= form.submit "Ask", name: "ask", value: "true", class: "w-full sm:w-auto rounded-md shadow-sm px-4 py-2 bg-green-600 hover:bg-green-700 text-white font-medium cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" %>
     </div>
   </div>
 <% end %>

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,11 @@
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV["OPENAI_API_KEY"] if ENV["OPENAI_API_KEY"].present?
+  config.anthropic_api_key = ENV["ANTHROPIC_API_KEY"] if ENV["ANTHROPIC_API_KEY"].present?
+  config.gemini_api_key = ENV["GEMINI_API_KEY"] if ENV["GEMINI_API_KEY"].present?
+  config.deepseek_api_key = ENV["DEEPSEEK_API_KEY"] if ENV["DEEPSEEK_API_KEY"].present?
+
+  config.bedrock_api_key = ENV["AWS_ACCESS_KEY_ID"] if ENV["AWS_ACCESS_KEY_ID"].present?
+  config.bedrock_secret_key = ENV["AWS_SECRET_ACCESS_KEY"] if ENV["AWS_SECRET_ACCESS_KEY"].present?
+  config.bedrock_region = ENV["AWS_REGION"] if ENV["AWS_REGION"].present?
+  config.bedrock_session_token = ENV["AWS_SESSION_TOKEN"] if ENV["AWS_SESSION_TOKEN"].present?
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,20 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "fileutils"
+require "ostruct"
+
+# Stub RubyLLM during tests to avoid network requests
+module RubyLLM
+  class TestChat
+    def ask(*)
+      OpenStruct.new(content: "Test response")
+    end
+  end
+
+  def self.chat(**)
+    TestChat.new
+  end
+end
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
## Summary
- integrate RubyLLM and configure from environment variables
- allow users to submit questions via a new **Ask** button when creating entries
- call the LLM with the entry text and optional image
- record the LLM response in the entry content
- stub RubyLLM in tests

## Testing
- `bundle exec rake test`