### PR TITLE
Unlock journal during system tests

### DIFF
--- a/bin/setup-codex-vm
+++ b/bin/setup-codex-vm
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
-# Put this into the setup script for Codex bin/setup-codex-vm
+# Setup script for running tests in the Codex VM
+
+set -e
+
+# Ensure packages required for system tests are installed before network
+# access is disabled. Chromedriver is needed for Capybara's headless Chrome
+# driver used in system tests.
+apt-get update -y
+apt-get install -y chromium-driver chromium-browser > /dev/null
 
 bundle install
 bin/rails db:prepare

--- a/test/system/entries_test.rb
+++ b/test/system/entries_test.rb
@@ -3,6 +3,13 @@ require "application_system_test_case"
 class EntriesTest < ApplicationSystemTestCase
   setup do
     @entry = entries(:one)
+    # Create a real encryption key and unlock the journal for system tests
+    @test_passphrase = "test-pass"
+    EncryptionKey.generate_and_save(@test_passphrase)
+
+    visit new_session_path
+    fill_in "Password", with: @test_passphrase
+    click_on "Unlock"
   end
 
   test "visiting the index" do


### PR DESCRIPTION
## Summary
- ensure system tests unlock the journal before accessing entries
- install chromedriver and browser in bin/setup-codex-vm for Codex

## Testing
- `bin/rails db:test:prepare test test:system` *(fails: Unable to obtain chromedriver)*
